### PR TITLE
feat: LLM chat backend with tool-use loop and AG-UI streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ infra/
 AGENTS.md
 .mcp.json
 CLAUDE.md
+.pi/
 
 # IDEs
 .vscode/

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -136,3 +136,10 @@ POSTGRES_DB=pypsa_app
 POSTGRES_USER=pypsa_app
 POSTGRES_PASSWORD=changeme
 POSTGRES_PORT=5432
+
+# LLM (Ollama via OpenAI-compat endpoint)
+CHAT_ENABLED=true
+LLM_PROVIDER=openai
+LLM_API_KEY=ollama
+LLM_API_BASE=http://ollama:11434/v1
+LLM_MODEL=qwen3.5:9b

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,38 @@ Environment variables for PyPSA App.
 | `SMTP_USE_TLS` | Use TLS/STARTTLS for SMTP connection | `true` |
 | `SMTP_FROM_ADDRESS` | Sender email address for notifications | `noreply@pypsa-app.local` |
 
+## LLM Chat
+
+Feature-flagged AI chat assistant for network analysis (disabled by default).
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CHAT_ENABLED` | Feature flag to enable AI chat endpoints | `false` |
+| `LLM_PROVIDER` | LLM provider name (e.g., `openai`, `anthropic`) | `openai` |
+| `LLM_MODEL` | LLM model identifier | `qwen3.5:9b` |
+| `LLM_API_KEY` | API key or bearer token for the LLM provider | - |
+| `LLM_API_BASE` | Custom API base URL for the LLM provider (omit to use provider default) | - |
+| `LLM_MAX_TOKENS` | Maximum tokens per completion | `2048` |
+| `LLM_TEMPERATURE` | Sampling temperature (0.0–2.0) | `0.2` |
+| `LLM_REQUEST_TIMEOUT_SECONDS` | Request timeout in seconds for provider calls | `120` |
+| `LLM_MAX_TOOL_ITERATIONS` | Maximum tool-calling loop iterations per chat request | `8` |
+| `LLM_INTERNAL_API_BASE` | Base URL for internal HTTP calls from chat tools to the app's own REST API | auto-derived from `LLM_INTERNAL_PORT` |
+| `LLM_INTERNAL_PORT` | Port used to derive `LLM_INTERNAL_API_BASE` when not set explicitly | `8000` |
+
+### Quick Start (Ollama)
+
+```bash
+export CHAT_ENABLED=true
+export LLM_PROVIDER=openai
+export LLM_MODEL=qwen3.5:9b
+export LLM_API_KEY=your-bearer-token
+export LLM_API_BASE=http://localhost:11434/v1
+```
+
+> [!NOTE]
+> For Ollama models, use `openai/` as the provider prefix — **not** `ollama/` — to avoid a LiteLLM
+> bug that drops `tool_calls` for reasoning models.
+
 ## Development
 
 | Variable | Description | Default |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "markupsafe>=3.0,<4",
     "platformdirs>=4",
     "slowapi>=0.1.9,<0.2",
+    "litellm>=1.83",
 ]
 
 [project.optional-dependencies]

--- a/src/pypsa_app/backend/alembic/versions/0007_network_is_solved.py
+++ b/src/pypsa_app/backend/alembic/versions/0007_network_is_solved.py
@@ -1,0 +1,35 @@
+"""Add is_solved and objective columns to networks table.
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-05-19
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0007"
+down_revision: str | None = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "networks",
+        sa.Column(
+            "is_solved",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column("networks", sa.Column("objective", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("networks", "objective")
+    op.drop_column("networks", "is_solved")

--- a/src/pypsa_app/backend/api/deps.py
+++ b/src/pypsa_app/backend/api/deps.py
@@ -27,8 +27,14 @@ from pypsa_app.backend.permissions import (
     can_modify,
     has_permission,
 )
+from pypsa_app.backend.settings import Settings, settings
 
 logger = logging.getLogger(__name__)
+
+
+def get_settings() -> Settings:
+    """FastAPI dependency that provides the application Settings."""
+    return settings
 
 
 def get_db() -> Generator[Session]:

--- a/src/pypsa_app/backend/api/routes/version.py
+++ b/src/pypsa_app/backend/api/routes/version.py
@@ -19,4 +19,5 @@ async def get_version() -> dict:
         "local_mode": settings.local_mode,
         "demo_mode": settings.demo_mode,
         "runs_enabled": bool(settings.resolved_backends) or settings.demo_mode,
+        "chat_enabled": settings.llm.chat_enabled,
     }

--- a/src/pypsa_app/backend/main.py
+++ b/src/pypsa_app/backend/main.py
@@ -49,6 +49,7 @@ from pypsa_app.backend.services.backend_registry import backend_registry
 from pypsa_app.backend.services.run import SnakedispatchError
 from pypsa_app.backend.services.sync import run_sync_loop
 from pypsa_app.backend.settings import API_V1_PREFIX, SESSION_COOKIE_NAME, settings
+from pypsa_app.llm.api.routes import router as llm_router
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -349,6 +350,7 @@ app.include_router(version.router, prefix=f"{API_V1_PREFIX}/version", tags=["ver
 app.include_router(tasks.router, prefix=f"{API_V1_PREFIX}/tasks", tags=["tasks"])
 if settings.resolved_backends or settings.demo_mode:
     app.include_router(runs.router, prefix=f"{API_V1_PREFIX}/runs", tags=["runs"])
+app.include_router(llm_router, prefix=API_V1_PREFIX, tags=["chat"])
 
 
 # Health check endpoint

--- a/src/pypsa_app/backend/models.py
+++ b/src/pypsa_app/backend/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     CheckConstraint,
     Column,
     Enum,
+    Float,
     ForeignKey,
     Integer,
     String,
@@ -247,6 +248,8 @@ class Network(Base):
     facets: Mapped[Any | None] = mapped_column(JSON)
     reports: Mapped[Any | None] = mapped_column(JSON)
     topology_svg: Mapped[str | None] = mapped_column(Text)
+    is_solved: Mapped[bool] = mapped_column(default=False, nullable=False)
+    objective: Mapped[float | None] = mapped_column(Float)
 
     @property
     def tags(self) -> list | None:

--- a/src/pypsa_app/backend/schemas/network.py
+++ b/src/pypsa_app/backend/schemas/network.py
@@ -50,6 +50,10 @@ class NetworkResponse(BaseModel):
     owner: UserPublicResponse
     source_run_id: UUID | None = None
 
+    # Optimisation state (from pypsa.Network.is_solved / .objective)
+    is_solved: bool = False
+    objective: float | None = None
+
     # Model properties
     tags: list[str | dict] | None = None
 

--- a/src/pypsa_app/backend/schemas/version.py
+++ b/src/pypsa_app/backend/schemas/version.py
@@ -9,3 +9,4 @@ class VersionResponse(BaseModel):
     local_mode: bool
     demo_mode: bool
     runs_enabled: bool
+    chat_enabled: bool = False

--- a/src/pypsa_app/backend/services/network.py
+++ b/src/pypsa_app/backend/services/network.py
@@ -176,6 +176,10 @@ class NetworkService:
             else {}
         )
 
+        info["is_solved"] = bool(getattr(self.n, "is_solved", False))
+        objective = getattr(self.n, "objective", None)
+        info["objective"] = float(objective) if objective is not None else None
+
         facets = {}
         if carriers := self._extract_carriers(self.n):
             facets["carriers"] = carriers
@@ -312,6 +316,8 @@ def _apply_network_metadata(network: Network, file_path: Path, file_hash: str) -
     network.components_count = info["components_count"]
     network.meta = info["meta"]
     network.facets = info["facets"]
+    network.is_solved = info["is_solved"]
+    network.objective = info["objective"]
     # SQLite stores naive datetimes; strip tzinfo but always generate UTC.
     network.update_history = [
         *(network.update_history or []),

--- a/src/pypsa_app/backend/services/statistics.py
+++ b/src/pypsa_app/backend/services/statistics.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_statistics(file_paths: list[str], statistic: str, parameters: dict) -> dict:
-    """Get statistics from network files (handles single or multiple networks)"""
+    """Get statistics from network files (handles single or multiple networks)."""
     service = load_service(file_paths, use_cache=True)
     stats_data = getattr(service.n.statistics, statistic)(**parameters)
 

--- a/src/pypsa_app/backend/settings.py
+++ b/src/pypsa_app/backend/settings.py
@@ -5,8 +5,10 @@ from pathlib import Path
 from typing import Self
 
 from platformdirs import user_data_dir
-from pydantic import Field, model_validator
+from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from pypsa_app.llm.settings import LLMSettings
 
 logger = logging.getLogger(__name__)
 
@@ -300,6 +302,9 @@ class Settings(BaseSettings):
         ),
         json_schema_extra={"category": "Development", "depends_on": "backend_only"},
     )
+
+    # LLM
+    llm: LLMSettings = Field(default_factory=LLMSettings)
 
     @model_validator(mode="after")
     def validate_oauth_credential_pairs(self) -> Self:

--- a/src/pypsa_app/backend/spa_static_files.py
+++ b/src/pypsa_app/backend/spa_static_files.py
@@ -7,8 +7,10 @@ from http import HTTPStatus
 
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 from starlette.types import Scope
+
+from pypsa_app.backend.settings import API_V1_PREFIX
 
 
 class SPAStaticFiles(StaticFiles):
@@ -19,7 +21,17 @@ class SPAStaticFiles(StaticFiles):
             return await super().get_response(path, scope)
         except HTTPException as ex:
             if ex.status_code == HTTPStatus.NOT_FOUND:
-                # Return index.html for all non-file routes
-                # This allows SvelteKit's client-side router to handle the route
+                # Unmatched /api/v1/* paths must return JSON 404, not the SPA shell —
+                # otherwise SPA fetch callers crash parsing HTML as JSON.
+                request_path = scope.get("path", "") or f"/{path}"
+                if request_path == API_V1_PREFIX or request_path.startswith(
+                    f"{API_V1_PREFIX}/"
+                ):
+                    return JSONResponse(
+                        status_code=HTTPStatus.NOT_FOUND,
+                        content={"detail": "Not Found"},
+                    )
+                # Return index.html for non-API routes so SvelteKit's client-side
+                # router can handle them.
                 return await super().get_response("index.html", scope)
             raise

--- a/src/pypsa_app/llm/api/deps.py
+++ b/src/pypsa_app/llm/api/deps.py
@@ -1,0 +1,57 @@
+"""FastAPI dependency providers for the chat API routes."""
+
+from typing import Annotated
+
+import httpx
+from fastapi import Depends, HTTPException, status
+
+from pypsa_app.backend.api.deps import get_settings
+from pypsa_app.backend.settings import Settings
+from pypsa_app.llm.client import LLMClient
+from pypsa_app.llm.service import ChatService
+from pypsa_app.llm.tools import ToolRegistry, build_default_registry
+from pypsa_app.llm.tools.http_client import build_internal_http_client
+
+
+def require_chat_enabled(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> None:
+    if not settings.llm.chat_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="chat is disabled",
+        )
+
+
+def get_llm_client(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> LLMClient:
+    """Return an :class:`LLMClient` configured from the application settings."""
+    return LLMClient(settings.llm)
+
+
+def get_internal_http_client(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> httpx.AsyncClient:
+    """Return an :class:`httpx.AsyncClient` pointed at the app's own REST API."""
+    return build_internal_http_client(settings)
+
+
+def get_tool_registry(
+    http: Annotated[httpx.AsyncClient, Depends(get_internal_http_client)],
+) -> ToolRegistry:
+    """Return a :class:`ToolRegistry` populated with all default tools."""
+    return build_default_registry(http)
+
+
+def get_chat_service(
+    client: Annotated[LLMClient, Depends(get_llm_client)],
+    registry: Annotated[ToolRegistry, Depends(get_tool_registry)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> ChatService:
+    """Return a fully wired :class:`ChatService`."""
+    return ChatService(
+        client=client,
+        tools=registry,
+        settings=settings.llm,
+    )

--- a/src/pypsa_app/llm/api/routes.py
+++ b/src/pypsa_app/llm/api/routes.py
@@ -1,0 +1,84 @@
+"""FastAPI router for the /api/v1/chat endpoints."""
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import StreamingResponse
+
+from pypsa_app.backend.api.deps import get_active_user
+from pypsa_app.backend.models import User
+from pypsa_app.backend.settings import SESSION_COOKIE_NAME
+from pypsa_app.llm.api.deps import get_chat_service, require_chat_enabled
+from pypsa_app.llm.api.schemas import ChatRequest
+from pypsa_app.llm.service import ChatService
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.post(
+    "/chat/stream",
+    dependencies=[Depends(require_chat_enabled)],
+    response_class=StreamingResponse,
+)
+async def chat_stream(
+    body: ChatRequest,
+    request: Request,
+    user: Annotated[User, Depends(get_active_user)],
+    service: Annotated[ChatService, Depends(get_chat_service)],
+) -> StreamingResponse:
+    sse_headers = {
+        "Cache-Control": "no-cache, no-transform",
+        "X-Accel-Buffering": "no",
+        "Connection": "keep-alive",
+    }
+
+    async def stream() -> AsyncIterator[bytes]:
+        auth_cookie = request.cookies.get(SESSION_COOKIE_NAME)
+        try:
+            async for sse_bytes in service.run_chat(
+                user=user,
+                messages=body.messages,
+                context=body.context,
+                client_disconnected=request.is_disconnected,
+                auth_cookie=auth_cookie,
+            ):
+                yield sse_bytes
+                if await request.is_disconnected():
+                    logger.info(
+                        "chat stream cancelled",
+                        extra={
+                            "user_id": user.id,
+                            "reason": "client_disconnect",
+                        },
+                    )
+                    return
+        except asyncio.CancelledError:
+            logger.info(
+                "chat stream cancelled",
+                extra={
+                    "user_id": user.id,
+                    "reason": "client_disconnect",
+                },
+            )
+            raise
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers=sse_headers,
+    )
+
+
+@router.get(
+    "/chat/health",
+    dependencies=[Depends(require_chat_enabled)],
+)
+async def chat_health(
+    service: Annotated[ChatService, Depends(get_chat_service)],
+) -> dict[str, object]:
+    """Cheap readiness check — pings the LLM provider with a 1-token completion."""
+    return await service.health()

--- a/src/pypsa_app/llm/api/schemas.py
+++ b/src/pypsa_app/llm/api/schemas.py
@@ -1,0 +1,78 @@
+"""Pydantic request/response models for the chat API."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class ChatToolCall(BaseModel):
+    """A tool call recorded on a prior assistant message.
+
+    Mirrors the frontend ``ToolCall`` shape but only carries the fields
+    the backend needs to reconstruct OpenAI ``tool_calls`` on the next
+    turn (id, name, args). Streaming-state fields (``args_partial``,
+    ``status``) are intentionally not modelled here.
+    """
+
+    id: str
+    name: str
+    args: dict[str, Any] | None = None
+
+
+class ChatToolResult(BaseModel):
+    """A tool result attached to a prior assistant message.
+
+    The backend turns each of these into a ``role: "tool"`` message
+    in the OpenAI message array so the model sees prior tool output
+    on subsequent turns.
+    """
+
+    tool_call_id: str
+    result: Any | None = None
+    is_error: bool = False
+    error: str | None = None
+
+
+class ChatMessage(BaseModel):
+    """A single message in a chat conversation.
+
+    Mirrors the frontend Message / AssistantMessage shape so the wire
+    format stays stable even if backend persistence is added later.
+    Assistant messages carry ``tool_calls`` and ``tool_results`` arrays
+    when prior turns invoked tools — the backend expands them into
+    OpenAI tool/tool-message pairs before sending to the provider.
+    """
+
+    id: str
+    role: Literal["user", "assistant", "tool"]
+    content: str = ""
+    tool_call_id: str | None = None
+    tool_name: str | None = None
+    tool_calls: list[ChatToolCall] | None = None
+    tool_results: list[ChatToolResult] | None = None
+    timestamp: str  # ISO-8601, advisory only — server reorders by array index
+
+
+class ChatContext(BaseModel):
+    """Context the frontend injects so the LLM knows what the user is looking at.
+
+    ``active_network_id`` / ``active_network_name`` carry the network the
+    user is currently viewing — informational only, never used to bind
+    ambiguous references to a network. ``previous_active_network_*`` are
+    populated only on the turn where the active network changed since
+    the previous message, so the model can be told about the switch.
+    """
+
+    active_network_id: str | None = None
+    active_network_name: str | None = None
+    previous_active_network_id: str | None = None
+    previous_active_network_name: str | None = None
+
+
+class ChatRequest(BaseModel):
+    """Body of ``POST /api/v1/chat/stream``."""
+
+    messages: list[ChatMessage]
+    context: ChatContext = Field(default_factory=ChatContext)

--- a/src/pypsa_app/llm/client.py
+++ b/src/pypsa_app/llm/client.py
@@ -1,0 +1,121 @@
+"""Async wrapper around the LLM provider (LiteLLM)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import litellm
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from pypsa_app.llm.settings import LLMSettings
+
+# Silently ignore provider-specific kwargs that LiteLLM does not recognise.
+litellm.drop_params = True
+
+
+def extract_reasoning(delta: object) -> str:
+    """Normalise reasoning content across providers.
+
+    Different providers expose reasoning / thinking content under
+    different attribute names on the delta object:
+
+    * Anthropic   → ``delta.thinking``
+    * Ollama qwen → ``delta.reasoning_content``
+    * OpenAI o1   → folded into content; not separately streamed
+
+    Args:
+        delta: A LiteLLM delta object (typically
+            ``chunk.choices[0].delta``).
+
+    Returns:
+        The reasoning string, or ``""`` if neither field is present.
+    """
+    return (
+        getattr(delta, "thinking", None)
+        or getattr(delta, "reasoning_content", None)
+        or ""
+    )
+
+
+def extract_text(delta: object) -> str:
+    """Extract the plain-text content from a streaming delta.
+
+    Args:
+        delta: A LiteLLM delta object (typically
+            ``chunk.choices[0].delta``).
+
+    Returns:
+        The text content string, or ``""`` if the ``content``
+        attribute is absent or empty.
+    """
+    return getattr(delta, "content", None) or ""
+
+
+class LLMClient:
+    """Async LiteLLM wrapper that routes completions through the configured provider.
+
+    Ollama models must use the ``openai/`` prefix: LiteLLM's ``ollama/`` adapter
+    drops ``tool_calls`` for reasoning models.
+    """
+
+    def __init__(self, settings: LLMSettings) -> None:
+        self._s = settings
+
+    async def stream(
+        self,
+        messages: list[dict[str, str]],
+        tools: list[dict[str, Any]] | None = None,
+    ) -> AsyncIterator[Any]:  # noqa: ANN401 — litellm chunks are opaque to callers
+        """Stream completion chunks from the configured LLM provider.
+
+        Args:
+            messages: Conversation history in OpenAI chat format.
+            tools: Optional list of OpenAI tool definitions.
+
+        Yields:
+            Raw LiteLLM ``ModelResponse`` chunks as returned by the provider.
+        """
+        kwargs: dict[str, Any] = {
+            "model": self._s.model_string,
+            "messages": messages,
+            "max_tokens": self._s.llm_max_tokens,
+            "temperature": self._s.llm_temperature,
+            "stream": True,
+            "timeout": self._s.llm_request_timeout_seconds,
+        }
+        if self._s.llm_api_key:
+            kwargs["api_key"] = self._s.llm_api_key
+        if self._s.llm_api_base:
+            kwargs["api_base"] = self._s.llm_api_base
+        if tools:
+            kwargs["tools"] = tools
+        if self._s.llm_reasoning_effort is not None:
+            kwargs["reasoning_effort"] = self._s.llm_reasoning_effort
+
+        stream = await litellm.acompletion(**kwargs)
+        async for chunk in stream:
+            yield chunk
+
+    async def health(self) -> dict[str, object]:
+        """Ping the LLM provider with a 1-token completion.
+
+        Returns:
+            ``{"ok": True, "model": self._s.model_string}`` on success.
+
+        Raises:
+            Any exception from the provider (connection, auth, rate-limit,
+            timeout, etc.) bubbles to the caller.
+        """
+        kwargs: dict[str, object] = {
+            "model": self._s.model_string,
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 1,
+        }
+        if self._s.llm_api_key:
+            kwargs["api_key"] = self._s.llm_api_key
+        if self._s.llm_api_base:
+            kwargs["api_base"] = self._s.llm_api_base
+        await litellm.acompletion(**kwargs)
+        return {"ok": True, "model": self._s.model_string}

--- a/src/pypsa_app/llm/events.py
+++ b/src/pypsa_app/llm/events.py
@@ -1,0 +1,188 @@
+"""AG-UI event dataclasses and SSE serializer for chat streaming."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+@dataclass(slots=True, frozen=True)
+class Usage:
+    """Token usage reported by the LLM provider."""
+
+    input_tokens: int
+    output_tokens: int
+
+
+@dataclass(slots=True, frozen=True)
+class RunStarted:
+    """Emitted when a chat turn begins."""
+
+    run_id: str
+    model: str
+
+
+@dataclass(slots=True, frozen=True)
+class RunFinished:
+    """Emitted when the assistant finishes responding."""
+
+    run_id: str
+    usage: Usage
+    stop_reason: str
+
+
+@dataclass(slots=True, frozen=True)
+class RunError:
+    """Emitted when an unrecoverable error occurs mid-run."""
+
+    run_id: str
+    code: str
+    message: str
+
+
+@dataclass(slots=True, frozen=True)
+class TextMessageContent:
+    """Streaming text-content delta from the assistant."""
+
+    message_id: str
+    delta: str
+
+
+@dataclass(slots=True, frozen=True)
+class ReasoningMessageContent:
+    """Streaming reasoning-content delta from the assistant."""
+
+    message_id: str
+    delta: str
+
+
+@dataclass(slots=True, frozen=True)
+class ToolCallStart:
+    """Emitted when the LLM decides to call a tool."""
+
+    tool_call_id: str
+    tool_name: str
+
+
+@dataclass(slots=True, frozen=True)
+class ToolCallArgs:
+    """Streamed JSON-fragment of tool-call arguments."""
+
+    tool_call_id: str
+    delta: str
+
+
+@dataclass(slots=True, frozen=True)
+class ToolCallEnd:
+    """All argument deltas received; tool about to execute."""
+
+    tool_call_id: str
+    args: Any = None  # noqa: ANN401 – arbitrary JSON payload
+
+
+@dataclass(slots=True, frozen=True)
+class ToolCallResult:
+    """Emitted after a tool invocation completes or fails."""
+
+    tool_call_id: str
+    result: Any = None  # noqa: ANN401 – arbitrary JSON payload
+    is_error: bool = False
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.is_error and self.error is None:
+            msg = "error must be a non-None string when is_error is True"
+            raise ValueError(msg)
+
+
+RunEvent = (
+    RunStarted
+    | RunFinished
+    | RunError
+    | TextMessageContent
+    | ReasoningMessageContent
+    | ToolCallStart
+    | ToolCallArgs
+    | ToolCallEnd
+    | ToolCallResult
+)
+"""Union of all event types accepted by :func:`sse_encode`."""
+
+
+def to_sse(event: RunEvent) -> bytes:
+    """Serialize an event dataclass to compact SSE wire-format bytes.
+
+    Uses compact JSON (no spaces) for predictable downstream parsing.
+    """
+    event_name = type(event).__name__
+    payload = json.dumps(asdict(event), separators=(",", ":"))
+    return f"event: {event_name}\ndata: {payload}\n\n".encode()
+
+
+_KEEPALIVE_BYTES = b":keepalive\n\n"
+
+
+async def heartbeat(
+    gen: AsyncIterator[bytes],
+    *,
+    interval: float = 15.0,
+) -> AsyncIterator[bytes]:
+    """Wrap an SSE byte generator with keepalive comment lines.
+
+    If the wrapped generator does not yield for *interval* seconds,
+    a ``:keepalive\\n\\n`` comment line is emitted to prevent proxies
+    and load balancers from closing the connection.
+
+    The underlying generator's ``__anext__()`` is never cancelled —
+    heartbeats are sent while the generator is still awaiting its
+    next item.
+    """
+    next_task: asyncio.Task[bytes] | None = None
+    cancelled = False
+
+    try:
+        while not cancelled:
+            if next_task is None:
+                next_task = asyncio.ensure_future(gen.__anext__())
+
+            sleep_task = asyncio.ensure_future(asyncio.sleep(interval))
+
+            done, pending = await asyncio.wait(
+                [next_task, sleep_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            # Cancel the sleep task (it's no longer needed).
+            # Never cancel next_task — it holds the pending generator step.
+            if sleep_task in pending:
+                sleep_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await sleep_task
+
+            if next_task in done:
+                try:
+                    result = next_task.result()
+                    yield result
+                    next_task = None  # reset — next iteration fetches a new item
+                except StopAsyncIteration:
+                    return
+                except asyncio.CancelledError:
+                    return
+            else:
+                # Timer fired before the generator produced output
+                yield _KEEPALIVE_BYTES
+                # next_task is still pending — keep it for the next loop
+    except asyncio.CancelledError:
+        cancelled = True
+        if next_task is not None and not next_task.done():
+            next_task.cancel()
+        raise
+    finally:
+        if next_task is not None and not next_task.done():
+            next_task.cancel()

--- a/src/pypsa_app/llm/prompts.py
+++ b/src/pypsa_app/llm/prompts.py
@@ -1,0 +1,115 @@
+"""System-prompt templates and builder helpers for chat interactions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pypsa_app.llm.api.schemas import ChatContext
+
+BASE_SYSTEM_PROMPT = """\
+You are a copilot embedded in the PyPSA App, a tool for inspecting and
+analysing power-system networks. You answer questions by calling the tools
+listed below — never invent numbers, network names, or component counts;
+always look them up.
+
+## What you CAN do (via tools)
+- `list_networks` — list networks the user can see, with pagination.
+- `get_network_detail` — return curated metadata for one network: component
+  counts (Bus/Generator/Line/...), dimensions (timesteps, periods,
+  scenarios), carriers, countries, file size, owner, visibility, plus a
+  small `meta_summary` (top-level meta keys + serialized size).
+- `get_network_statistics` — invoke ONE PyPSA stats method per call
+  (e.g. `capex`, `installed_capacity`, `capacity_factor`, or `summary`
+  for the multi-column overview) with `groupby` (carrier/bus/country),
+  `groupby_time`, `groupby_method`, and `carrier`/`bus_carrier` filters.
+  All results are aggregated — no raw hourly time-series. When you need
+  several methods (e.g. a costs overview), emit several tool_calls in
+  the same turn and the harness fans them out in parallel.
+
+## What you CANNOT do
+- You cannot run optimisations, dispatch simulations, or solve networks.
+- You cannot upload, edit, rename, or delete networks.
+- You cannot generate plots or files; the chat UI may render charts/tables
+  from the structured `data` your tools return, but you do not produce
+  images or downloads.
+- You cannot read raw hourly time-series; statistics are always aggregated.
+
+If the user asks for any of the above, say so plainly and suggest the closest
+inspect/summarise capability you do have. Do not list capabilities you don't
+actually have.
+
+## PyPSA conventions you must respect
+- **Units are MW for power components** (Generator, Link, Line) and
+  **MWh for energy components** (Store, StorageUnit). The
+  `get_network_statistics` response includes a `units` string for the
+  requested method — use it. Do not invent units. A value like `1000000` for
+  Solar PV is **1 GW = 1,000 MW**, perfectly normal at country scale —
+  do not call it "suspiciously round".
+- **`installed_capacity`** is the existing capacity already in the
+  network. **`optimal_capacity`** is the result of the optimisation —
+  for a *dispatch-only* run it equals `installed_capacity` because no
+  expansion is allowed. **`expanded_capacity`** is the *new* capacity
+  the optimiser built — for a dispatch-only run it is zero everywhere,
+  and that is the correct answer, not a bug.
+- **`capacity_factor`** is dimensionless, between 0 and 1 (or as a
+  percentage in conversation: 0.83 → "83%"). Do not multiply by MW.
+- **`curtailment`** is in MWh, energy not power. Treat values for
+  fossil carriers as a flag (real curtailment is renewable).
+- **CO₂ entries** are in tonnes (`co2 sequestered`, `co2 stored`,
+  `co2 emissions`). They are not energy — never list them next to
+  generator capacities.
+
+## How to respond
+- When you call a tool, summarise the result in plain language. The UI
+  renders structured `data` separately — your text should explain *what*
+  the data means, not just restate it.
+- To tell whether a network has been optimised, use the `is_solved` field
+  returned by `get_network_detail` (this mirrors PyPSA's own
+  `Network.is_solved` — it is true if an objective value is stored on
+  the network). Do NOT infer solved/unsolved status from `source_run_id`.
+- If a tool returns a `network_not_solved` warning, say so clearly: stats
+  for unsolved networks will be empty for capacity_factor, market_value,
+  prices, etc.
+- If a tool errors, report the error verbatim and stop — don't fabricate
+  fallback data and simply say the information is not provided.
+- Across turns, you can see what tools you already called and what they
+  returned. Don't re-call a tool with identical arguments — refer to the
+  prior result instead."""
+
+
+def build_system_prompt(context: ChatContext) -> str:
+    """Assemble the system prompt from the base template and active context.
+
+    Returns only ``BASE_SYSTEM_PROMPT`` when the context carries no
+    active-network information. When ``previous_active_network_*`` is
+    set, appends a one-turn notice that the active network just changed
+    — the system prompt is rebuilt per turn, so the notice naturally
+    expires on the next turn.
+    """
+    parts = [BASE_SYSTEM_PROMPT]
+    if context.active_network_id and context.active_network_name:
+        parts.append(
+            f"The user is currently viewing network "
+            f'"{context.active_network_name}" (id: {context.active_network_id}). '
+            f"This is informational context only — the user may ask about "
+            f"this network or any other. Always pass an explicit network_id "
+            f"in tool calls; do not assume the active network is the subject "
+            f"of the question. Use list_networks to discover other networks."
+        )
+    if context.previous_active_network_id:
+        prev_name = context.previous_active_network_name or "(unknown)"
+        if context.active_network_id:
+            parts.append(
+                f"Note: since the previous message, the user's active network "
+                f'changed from "{prev_name}" '
+                f"(id: {context.previous_active_network_id}) to the current one."
+            )
+        else:
+            parts.append(
+                f"Note: since the previous message, the user navigated away "
+                f'from network "{prev_name}" (id: '
+                f"{context.previous_active_network_id}) and is no longer "
+                f"viewing a specific network."
+            )
+    return "\n\n".join(parts)

--- a/src/pypsa_app/llm/service.py
+++ b/src/pypsa_app/llm/service.py
@@ -1,0 +1,451 @@
+"""Core chat orchestration: combines LLM calls with tool execution."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import litellm.exceptions
+
+from pypsa_app.llm.client import extract_reasoning, extract_text
+from pypsa_app.llm.events import (
+    ReasoningMessageContent,
+    RunError,
+    RunFinished,
+    RunStarted,
+    TextMessageContent,
+    ToolCallArgs,
+    ToolCallEnd,
+    ToolCallResult,
+    ToolCallStart,
+    Usage,
+    to_sse,
+)
+from pypsa_app.llm.prompts import build_system_prompt
+from pypsa_app.llm.tools.base import ToolContext
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from pypsa_app.backend.models import User
+    from pypsa_app.llm.api.schemas import ChatContext, ChatMessage
+    from pypsa_app.llm.client import LLMClient
+    from pypsa_app.llm.settings import LLMSettings
+    from pypsa_app.llm.tools import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+_DISCONNECT_MSG = "client disconnected"
+
+
+def _process_delta(
+    delta: Any,  # noqa: ANN401 — LLM SDK dynamic object
+    index_buffers: dict[int, dict[str, str]],
+    message_id: str,
+) -> list[bytes]:
+    """Process a single stream chunk delta, returning SSE bytes.
+
+    Handles tool-call delta buffering (ToolCallStart / ToolCallArgs),
+    text content (TextMessageContent), and reasoning content
+    (ReasoningMessageContent) for one chunk.
+    """
+    events: list[bytes] = []
+
+    # ── tool-call deltas ──────────────────────────
+    tool_calls = getattr(delta, "tool_calls", None) or []
+    for tc_delta in tool_calls:
+        tc_index = getattr(tc_delta, "index", 0)
+        tc_id = getattr(tc_delta, "id", None)
+        tc_fn = getattr(tc_delta, "function", None)
+        tc_args = getattr(tc_fn, "arguments", "") if tc_fn else ""
+        tc_name = getattr(tc_fn, "name", None) if tc_fn else None
+
+        # First appearance: buffer and emit ToolCallStart
+        if tc_index not in index_buffers:
+            resolved_id = tc_id or f"call_{tc_index}"
+            resolved_name = tc_name or "unknown"
+            index_buffers[tc_index] = {
+                "id": resolved_id,
+                "name": resolved_name,
+                "args_str": "",
+            }
+            events.append(
+                to_sse(
+                    ToolCallStart(
+                        tool_call_id=resolved_id,
+                        tool_name=resolved_name,
+                    )
+                )
+            )
+
+        buf = index_buffers[tc_index]
+        if tc_args:
+            buf["args_str"] += tc_args
+            events.append(
+                to_sse(
+                    ToolCallArgs(
+                        tool_call_id=buf["id"],
+                        delta=tc_args,
+                    )
+                )
+            )
+
+    # ── text deltas ───────────────────────────────
+    text: str = extract_text(delta)
+    if text:
+        events.append(to_sse(TextMessageContent(message_id=message_id, delta=text)))
+
+    # ── reasoning deltas ──────────────────────────
+    reasoning: str = extract_reasoning(delta)
+    if reasoning:
+        events.append(
+            to_sse(ReasoningMessageContent(message_id=message_id, delta=reasoning))
+        )
+
+    return events
+
+
+def _expand_messages(messages: list[ChatMessage]) -> list[dict[str, object]]:
+    """Convert ChatMessage entries to OpenAI-format messages.
+
+    User messages pass through unchanged. Assistant messages with
+    ``tool_calls`` are emitted with an OpenAI ``tool_calls`` array;
+    each entry in ``tool_results`` becomes a separate ``role: "tool"``
+    message immediately after, so the model sees both what it called
+    and what came back when continuing a multi-turn conversation.
+    """
+    expanded: list[dict[str, object]] = []
+    for m in messages:
+        if m.role == "assistant" and m.tool_calls:
+            tool_calls_payload = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.name,
+                        "arguments": json.dumps(tc.args or {}),
+                    },
+                }
+                for tc in m.tool_calls
+            ]
+            expanded.append(
+                {
+                    "role": "assistant",
+                    "content": m.content or None,
+                    "tool_calls": tool_calls_payload,
+                }
+            )
+            expanded.extend(
+                {
+                    "role": "tool",
+                    "tool_call_id": tr.tool_call_id,
+                    "content": json.dumps(
+                        tr.result if not tr.is_error else {"error": tr.error}
+                    ),
+                }
+                for tr in m.tool_results or []
+            )
+            continue
+        expanded.append({"role": m.role, "content": m.content})
+    return expanded
+
+
+def _cancel_on_disconnect(run_id: str) -> None:
+    """Raise CancelledError when the client has disconnected.
+
+    Cancellation must NOT emit RunError or RunFinished — the stream
+    simply ends.
+    """
+    logger.info(
+        "chat stream cancelled",
+        extra={"run_id": run_id, "reason": "client_disconnect"},
+    )
+    raise asyncio.CancelledError(_DISCONNECT_MSG) from None
+
+
+class ChatService:
+    """Orchestrates a chat turn: streams LLM deltas and invokes tools.
+
+    Emits ``RunStarted``, streams ``TextMessageContent`` deltas, detects
+    and streams tool calls (``ToolCallStart``, ``ToolCallArgs``,
+    ``ToolCallEnd``, ``ToolCallResult``), and finishes with
+    ``RunFinished``.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: LLMClient,
+        tools: ToolRegistry,
+        settings: LLMSettings,
+    ) -> None:
+        self._client = client
+        self._tools = tools
+        self._settings = settings
+
+    async def run_chat(
+        self,
+        *,
+        user: User,
+        messages: list[ChatMessage],
+        context: ChatContext,
+        client_disconnected: Any,  # noqa: ANN401 — async callable protocol
+        auth_cookie: str | None = None,
+    ) -> AsyncIterator[bytes]:
+        """Execute a chat turn, emitting AG-UI SSE events.
+
+        Streams text content deltas and tool-call events between
+        ``RunStarted`` and ``RunFinished`` bookend events. Supports up to
+        ``llm_max_tool_iterations`` tool-call round-trips.
+        """
+        run_id = f"run_{uuid.uuid4().hex[:12]}"
+        model = self._settings.model_string
+
+        logger.info(
+            "chat run started",
+            extra={"run_id": run_id, "user_id": user.id, "model": model},
+        )
+
+        yield to_sse(RunStarted(run_id=run_id, model=model))
+
+        openai_messages: list[dict[str, object]] = [
+            {"role": "system", "content": build_system_prompt(context)},
+            *_expand_messages(messages),
+        ]
+
+        tool_ctx = ToolContext(user_id=str(user.id), auth_cookie=auth_cookie)
+        tool_schemas = self._tools.schemas()
+        max_iterations = self._settings.llm_max_tool_iterations
+
+        for _iteration in range(max_iterations):
+            message_id = f"msg_{uuid.uuid4().hex[:12]}"
+            index_buffers: dict[int, dict[str, str]] = {}
+            finish_reason: str | None = None
+
+            try:
+                async for chunk in self._client.stream(
+                    openai_messages, tools=tool_schemas
+                ):
+                    delta = chunk.choices[0].delta
+                    finish_reason = getattr(chunk.choices[0], "finish_reason", None)
+
+                    for sse_bytes in _process_delta(delta, index_buffers, message_id):
+                        yield sse_bytes
+
+                    # ── client-disconnect check ───────────
+                    disconnected = client_disconnected()
+                    if asyncio.iscoroutine(disconnected):
+                        disconnected = await disconnected
+                    if disconnected:
+                        _cancel_on_disconnect(run_id)
+            except Exception as exc:
+                code, log_msg, is_critical = self._provider_error_code(exc)
+                if is_critical:
+                    logger.exception(
+                        log_msg,
+                        extra={"run_id": run_id, "error_code": code},
+                    )
+                else:
+                    logger.warning(
+                        log_msg,
+                        extra={"run_id": run_id, "error": str(exc)},
+                    )
+                yield to_sse(RunError(run_id=run_id, code=code, message=str(exc)))
+                return
+
+            if finish_reason == "tool_calls":
+                async for evt_bytes in self._finish_tool_calls(
+                    index_buffers, tool_ctx, openai_messages
+                ):
+                    yield evt_bytes
+                continue
+
+            yield to_sse(
+                RunFinished(
+                    run_id=run_id,
+                    usage=Usage(input_tokens=0, output_tokens=0),
+                    stop_reason=finish_reason or "end_turn",
+                )
+            )
+            return
+
+        # Loop exhausted — soft-stop: tell the model to wrap up without
+        # tools and stream a final summary so the user gets a coherent
+        # response instead of an error mid-stream.
+        logger.warning(
+            "tool iteration limit reached — soft-stopping with summary",
+            extra={"run_id": run_id, "iterations": max_iterations},
+        )
+        openai_messages.append(
+            {
+                "role": "user",
+                "content": (
+                    f"[System notice] You have reached the maximum of "
+                    f"{max_iterations} tool calls for this turn. Stop "
+                    f"calling tools now. Summarise for the user what you "
+                    f"have found so far, describe what remains unexamined, "
+                    f"and tell them they can reply 'continue' if they want "
+                    f"you to keep exploring."
+                ),
+            }
+        )
+        async for evt_bytes in self._stream_summary(run_id, openai_messages):
+            yield evt_bytes
+
+    async def health(self) -> dict[str, object]:
+        """Cheap readiness check — pings the LLM provider."""
+        return await self._client.health()
+
+    @staticmethod
+    def _provider_error_code(exc: Exception) -> tuple[str, str, bool]:
+        """Map a provider exception to (code, log_message, is_critical).
+
+        - httpx.TimeoutException → "provider_timeout"
+        - litellm.AuthenticationError → "provider_auth_failed"
+        - litellm.RateLimitError → "provider_rate_limit"
+        - anything else → "internal"
+        """
+        if isinstance(exc, httpx.TimeoutException):
+            return ("provider_timeout", "provider timeout", False)
+        if isinstance(exc, litellm.exceptions.AuthenticationError):
+            return ("provider_auth_failed", "provider auth failed", False)
+        if isinstance(exc, litellm.exceptions.RateLimitError):
+            return ("provider_rate_limit", "provider rate limit", False)
+        return ("internal", "chat run failed", True)
+
+    async def _stream_summary(
+        self,
+        run_id: str,
+        openai_messages: list[dict[str, object]],
+    ) -> AsyncIterator[bytes]:
+        """Stream a tools-disabled summary call and emit RunFinished.
+
+        Used by the soft-stop path when the tool-iteration cap is hit:
+        the model gets one final pass with no tools to wrap up the
+        conversation cleanly. Errors here surface as RunError(internal)
+        rather than crashing the stream.
+        """
+        summary_message_id = f"msg_{uuid.uuid4().hex[:12]}"
+        try:
+            async for chunk in self._client.stream(openai_messages, tools=None):
+                delta = chunk.choices[0].delta
+                text = extract_text(delta)
+                if text:
+                    yield to_sse(
+                        TextMessageContent(message_id=summary_message_id, delta=text)
+                    )
+                reasoning = extract_reasoning(delta)
+                if reasoning:
+                    yield to_sse(
+                        ReasoningMessageContent(
+                            message_id=summary_message_id, delta=reasoning
+                        )
+                    )
+        except Exception as exc:
+            code, log_msg, is_critical = self._provider_error_code(exc)
+            if is_critical:
+                logger.exception(log_msg, extra={"run_id": run_id, "error_code": code})
+            else:
+                logger.warning(log_msg, extra={"run_id": run_id, "error": str(exc)})
+            yield to_sse(RunError(run_id=run_id, code=code, message=str(exc)))
+            return
+
+        yield to_sse(
+            RunFinished(
+                run_id=run_id,
+                usage=Usage(input_tokens=0, output_tokens=0),
+                stop_reason="tool_iteration_limit",
+            )
+        )
+
+    async def _finish_tool_calls(
+        self,
+        index_buffers: dict[int, dict[str, str]],
+        tool_ctx: ToolContext,
+        openai_messages: list[dict[str, object]],
+    ) -> AsyncIterator[bytes]:
+        """Handle ``finish_reason == "tool_calls"``.
+
+        Emits ``ToolCallEnd`` and ``ToolCallResult`` for each buffered
+        tool call, then appends the assistant and tool messages to
+        ``openai_messages`` for the next iteration.
+        """
+        tool_msg_parts: list[dict[str, object]] = []
+        tool_responses: list[dict[str, object]] = []
+        for buf in index_buffers.values():
+            tcid = buf["id"]
+            args_str = buf["args_str"]
+
+            try:
+                args = json.loads(args_str) if args_str else {}
+            except json.JSONDecodeError as e:
+                msg = f"invalid json: {e}"
+                yield to_sse(
+                    ToolCallResult(
+                        tool_call_id=tcid,
+                        result=None,
+                        is_error=True,
+                        error=msg,
+                    )
+                )
+                tool_msg_parts.append(
+                    {
+                        "id": tcid,
+                        "type": "function",
+                        "function": {
+                            "name": buf["name"],
+                            "arguments": args_str,
+                        },
+                    }
+                )
+                tool_responses.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tcid,
+                        "content": json.dumps({"error": msg}),
+                    }
+                )
+                continue
+
+            yield to_sse(ToolCallEnd(tool_call_id=tcid, args=args))
+
+            tool_result = await self._tools.invoke(buf["name"], args, tool_ctx)
+            yield to_sse(
+                ToolCallResult(
+                    tool_call_id=tcid,
+                    result=tool_result.payload,
+                    is_error=tool_result.is_error,
+                    error=tool_result.error,
+                )
+            )
+
+            tool_msg_parts.append(
+                {
+                    "id": tcid,
+                    "type": "function",
+                    "function": {
+                        "name": buf["name"],
+                        "arguments": args_str,
+                    },
+                }
+            )
+            tool_responses.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tcid,
+                    "content": json.dumps(tool_result.payload),
+                }
+            )
+
+        openai_messages.append(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": tool_msg_parts,
+            }
+        )
+        openai_messages.extend(tool_responses)

--- a/src/pypsa_app/llm/settings.py
+++ b/src/pypsa_app/llm/settings.py
@@ -1,0 +1,105 @@
+"""LLM provider and generation configuration loaded from environment variables."""
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class LLMSettings(BaseSettings):
+    """LLM configuration sourced from environment variables.
+
+    Env vars are read with their exact upstream names (no prefix).
+    """
+
+    model_config = SettingsConfigDict(extra="ignore", populate_by_name=True)
+
+    llm_provider: str = Field(
+        default="openai",
+        alias="LLM_PROVIDER",
+        description="LLM provider name",
+    )
+    llm_model: str = Field(
+        default="qwen3.5:9b",
+        alias="LLM_MODEL",
+        description="LLM model identifier",
+    )
+    llm_api_key: str = Field(
+        default="",
+        alias="LLM_API_KEY",
+        description="API key for the configured provider",
+    )
+    llm_api_base: str | None = Field(
+        default=None,
+        alias="LLM_API_BASE",
+        description="Custom API base URL (optional)",
+    )
+    llm_internal_api_base: str | None = Field(
+        default=None,
+        alias="LLM_INTERNAL_API_BASE",
+        description="Base URL for internal HTTP calls to the app's own REST API",
+    )
+    llm_internal_port: int = Field(
+        default=8000,
+        alias="LLM_INTERNAL_PORT",
+        description="Port used when llm_internal_api_base is not set explicitly",
+    )
+
+    # Generation parameters
+    llm_max_tokens: int = Field(
+        default=2048,
+        alias="LLM_MAX_TOKENS",
+        description="Maximum tokens per completion",
+    )
+    llm_temperature: float = Field(
+        default=0.2,
+        alias="LLM_TEMPERATURE",
+        description="Sampling temperature",
+    )
+    llm_request_timeout_seconds: float = Field(
+        default=120.0,
+        alias="LLM_REQUEST_TIMEOUT_SECONDS",
+        description="Timeout in seconds for provider requests",
+    )
+    llm_reasoning_effort: str | None = Field(
+        default=None,
+        alias="LLM_REASONING_EFFORT",
+        description=(
+            "Reasoning effort for OpenAI-compatible reasoning models. "
+            "One of None (default, let provider decide), 'low', 'medium', 'high'. "
+            "Passed through as 'reasoning_effort' to the provider; LiteLLM's "
+            "drop_params=True means providers that don't support it just "
+            "ignore it."
+        ),
+    )
+
+    # Feature flag and tool execution limits
+    chat_enabled: bool = Field(
+        default=False,
+        alias="CHAT_ENABLED",
+        description="Feature flag to enable chat endpoints",
+    )
+    llm_max_tool_iterations: int = Field(
+        default=8,
+        alias="LLM_MAX_TOOL_ITERATIONS",
+        description="Maximum tool-calling loop iterations per chat request",
+    )
+
+    @property
+    def resolved_internal_api_base(self) -> str:
+        """The base URL for internal HTTP calls.
+
+        Returns ``llm_internal_api_base`` when explicitly set; otherwise
+        defaults to ``http://127.0.0.1:{llm_internal_port}``.
+        """
+        if self.llm_internal_api_base is not None:
+            return self.llm_internal_api_base
+        return f"http://127.0.0.1:{self.llm_internal_port}"
+
+    @property
+    def model_string(self) -> str:
+        """LiteLLM-style model identifier combining provider and model.
+
+        Returns ``{provider}/{model}``. For Ollama models, use the
+        ``openai/`` provider prefix — **not** ``ollama/`` — because the
+        ``ollama/`` prefix drops ``tool_calls`` for reasoning models.
+        """
+        return f"{self.llm_provider}/{self.llm_model}"

--- a/src/pypsa_app/llm/tools/__init__.py
+++ b/src/pypsa_app/llm/tools/__init__.py
@@ -1,0 +1,74 @@
+"""Tool registry — register, invoke, and tool-schema export."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from pypsa_app.llm.tools.base import Tool, ToolContext, ToolResult
+from pypsa_app.llm.tools.get_network_detail import GetNetworkDetailTool
+from pypsa_app.llm.tools.get_network_statistics import GetNetworkStatisticsTool
+from pypsa_app.llm.tools.list_networks import ListNetworksTool
+
+logger = logging.getLogger(__name__)
+
+
+class ToolRegistry:
+    """Holds registered :class:`Tool` instances and dispatches invocations by name.
+
+    Construct with a list of concrete tool instances.  The registry indexes
+    them by :attr:`Tool.name` so that lookups during a chat turn are O(1).
+    """
+
+    def __init__(self, tools: list[Tool]) -> None:
+        self._tools: dict[str, Tool] = {t.name: t for t in tools}
+
+    def schemas(self) -> list[dict[str, Any]]:
+        """Return OpenAI‑compatible function‑tool schemas for every registered tool."""
+        return [t.to_openai() for t in self._tools.values()]
+
+    async def invoke(
+        self, name: str, args: dict[str, Any], ctx: ToolContext
+    ) -> ToolResult:
+        """Look up *name* and delegate to :meth:`Tool.invoke`.
+
+        Returns:
+            A :class:`ToolResult` — on success from the tool itself; on
+            failure a synthetic error result so the stream never crashes.
+        """
+        tool = self._tools.get(name)
+        if tool is None:
+            msg = f"unknown tool: {name}"
+            return ToolResult(payload=None, is_error=True, error=msg)
+
+        try:
+            return await tool.invoke(args, ctx)
+        except httpx.HTTPStatusError as exc:
+            return ToolResult(
+                payload=None,
+                is_error=True,
+                error=f"http {exc.response.status_code}: {exc.response.text[:200]}",
+            )
+        except Exception as exc:  # noqa: BLE001 — surface to LLM, never crash the stream
+            logger.warning(
+                "tool execution error",
+                extra={"tool": name, "error": str(exc)},
+            )
+            return ToolResult(
+                payload=None,
+                is_error=True,
+                error=str(exc),
+            )
+
+
+def build_default_registry(http: httpx.AsyncClient) -> ToolRegistry:
+    """Build a :class:`ToolRegistry` populated with all default tools."""
+    return ToolRegistry(
+        [
+            ListNetworksTool(http),
+            GetNetworkDetailTool(http),
+            GetNetworkStatisticsTool(http),
+        ]
+    )

--- a/src/pypsa_app/llm/tools/base.py
+++ b/src/pypsa_app/llm/tools/base.py
@@ -1,0 +1,61 @@
+"""Base interface for LLM tool definitions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import httpx
+
+
+@dataclass(slots=True, frozen=True)
+class ToolContext:
+    """Immutable context passed to every tool invocation.
+
+    Carries the authenticated user's identity and a session cookie
+    that tools forward to internal HTTP calls so existing auth checks apply.
+    """
+
+    user_id: str
+    auth_cookie: str | None
+
+
+@dataclass(slots=True, frozen=True)
+class ToolResult:
+    """Return value of a tool invocation — success or failure."""
+
+    payload: dict[str, Any] | None
+    is_error: bool = False
+    error: str | None = None
+
+
+class Tool(ABC):
+    """Abstract tool that the LLM can invoke.
+
+    Subclasses must set ``name``, ``description``, and ``parameters_schema``
+    as class-level attributes and implement :meth:`invoke`.
+    """
+
+    name: str
+    description: str
+    parameters_schema: dict[str, Any]
+
+    def __init__(self, http: httpx.AsyncClient) -> None:
+        self._http = http
+
+    @abstractmethod
+    async def invoke(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        """Execute the tool with the given arguments and context."""
+
+    def to_openai(self) -> dict[str, Any]:
+        """Return an OpenAI-compatible function-tool schema."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters_schema,
+            },
+        }

--- a/src/pypsa_app/llm/tools/get_network_detail.py
+++ b/src/pypsa_app/llm/tools/get_network_detail.py
@@ -1,0 +1,116 @@
+"""Tool: structured summary of a single network.
+
+Returns a *curated* payload (component counts, dimensions, carriers,
+countries, file size, ownership, plus a small ``meta_summary`` listing
+top-level meta keys and serialized size) — never the full ``meta`` blob,
+which on real PyPSA-Eur networks is tens of KB of nested config and
+otherwise blows the model's context window.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pypsa_app.llm.tools.base import Tool, ToolContext, ToolResult
+from pypsa_app.llm.tools.http_client import cookies_for
+
+
+def _carrier_names(facets: dict[str, Any] | None) -> list[str]:
+    carriers = (facets or {}).get("carriers") or {}
+    return sorted(carriers.keys()) if isinstance(carriers, dict) else []
+
+
+def _countries(facets: dict[str, Any] | None) -> list[str]:
+    countries = (facets or {}).get("countries") or []
+    return list(countries) if isinstance(countries, list) else []
+
+
+def _meta_summary(meta: dict[str, Any] | None) -> dict[str, Any]:
+    meta = meta or {}
+    return {
+        "size_bytes": len(json.dumps(meta, default=str)),
+        "keys": sorted(meta.keys()) if isinstance(meta, dict) else [],
+    }
+
+
+def _last_updated_at(history: list[Any] | None) -> str | None:
+    return history[-1] if history else None
+
+
+class GetNetworkDetailTool(Tool):
+    """Structured summary of one network the current user can see."""
+
+    name = "get_network_detail"
+    description = (
+        "Get a structured summary of a single PyPSA energy network. "
+        "Returns id, name, filename, created_at, last_updated_at, "
+        "visibility, owner, file_size_bytes, dimensions_count "
+        "(timesteps/periods/scenarios), per-component counts (Bus, "
+        "Generator, Line, ...), carriers and countries present, plus a "
+        "small meta_summary listing the top-level meta keys and the meta "
+        "blob size in bytes. Also returns `is_solved` (canonical PyPSA "
+        "`Network.is_solved` — true if an objective value is stored) "
+        "and `objective` (the solved objective value, or null). The full "
+        "meta dictionary is intentionally NOT returned. Use "
+        "list_networks first to discover ids."
+    )
+    parameters_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "network_id": {
+                "type": "string",
+                "description": "UUID of the network. Get ids from list_networks.",
+            },
+        },
+        "required": ["network_id"],
+    }
+
+    async def invoke(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        network_id = args["network_id"]
+        r = await self._http.get(
+            f"/api/v1/networks/{network_id}",
+            cookies=cookies_for(ctx),
+        )
+        r.raise_for_status()
+        body: dict[str, Any] = r.json()
+
+        owner = body.get("owner") or {}
+        is_owner = owner.get("id") == ctx.user_id
+        name = body.get("name") or body.get("filename", "unnamed")
+
+        slim = {
+            "id": body.get("id"),
+            "name": name,
+            "filename": body.get("filename"),
+            "created_at": body.get("created_at"),
+            "last_updated_at": _last_updated_at(body.get("update_history")),
+            "visibility": body.get("visibility"),
+            "is_owner": is_owner,
+            "source_run_id": body.get("source_run_id"),
+            "is_solved": bool(body.get("is_solved", False)),
+            "objective": body.get("objective"),
+            "file_size_bytes": body.get("file_size"),
+            "dimensions_count": body.get("dimensions_count") or {},
+            "components_count": body.get("components_count") or {},
+            "carriers": _carrier_names(body.get("facets")),
+            "countries": _countries(body.get("facets")),
+            "meta_summary": _meta_summary(body.get("meta")),
+        }
+
+        components = slim["components_count"]
+        component_summary = ", ".join(
+            f"{k}={v}" for k, v in list(components.items())[:6]
+        )
+        ownership = "owned by you" if is_owner else "owned by another user"
+        summary = (
+            f"Network '{name}' (id: {network_id}), file '{slim['filename']}', "
+            f"{ownership}, components: {component_summary}."
+        )
+
+        return ToolResult(
+            payload={
+                "summary": summary,
+                "data": {"network": slim},
+            }
+        )

--- a/src/pypsa_app/llm/tools/get_network_statistics.py
+++ b/src/pypsa_app/llm/tools/get_network_statistics.py
@@ -1,0 +1,217 @@
+"""Tool: invoke ONE PyPSA stats method via the async statistics endpoint.
+
+Posts to ``POST /api/v1/statistics/``, polls
+``GET /api/v1/tasks/status/{task_id}`` until the Celery task reaches a
+terminal state, then post-processes the dataframe or series into a
+renderer-friendly payload.
+
+ONE method per call by design. When the LLM wants several methods, it
+emits parallel ``tool_calls`` in a single turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from pypsa_app.backend.utils.allowlists import ALLOWED_STATISTICS
+from pypsa_app.llm.tools.base import Tool, ToolContext, ToolResult
+from pypsa_app.llm.tools.http_client import cookies_for
+
+_UNITS: dict[str, str] = {
+    "installed_capacity": "MW (power) or MWh (stores/storage_units)",
+    "optimal_capacity": "MW (power) or MWh (stores/storage_units)",
+    "expanded_capacity": "MW (power) or MWh (stores/storage_units)",
+    "capex": "currency (typically EUR)",
+    "installed_capex": "currency (typically EUR)",
+    "expanded_capex": "currency (typically EUR)",
+    "fom": "currency/year",
+    "opex": "currency",
+    "system_cost": "currency",
+    "supply": "MWh",
+    "withdrawal": "MWh",
+    "transmission": "MWh",
+    "energy_balance": "MWh",
+    "capacity_factor": "fraction (0-1)",
+    "curtailment": "MWh",
+    "revenue": "currency",
+    "market_value": "currency/MWh",
+    "prices": "currency/MWh",
+}
+
+# Methods that depend on optimisation results — empty output usually means
+# the network has not been solved.
+_REQUIRES_OPTIMISATION: frozenset[str] = frozenset(
+    {
+        "supply",
+        "withdrawal",
+        "transmission",
+        "energy_balance",
+        "capacity_factor",
+        "curtailment",
+        "revenue",
+        "market_value",
+        "prices",
+        "opex",
+        "system_cost",
+    }
+)
+
+_OPTIONAL_PARAMS: tuple[str, ...] = (
+    "groupby",
+    "groupby_time",
+    "groupby_method",
+    "carrier",
+    "bus_carrier",
+)
+
+class GetNetworkStatisticsTool(Tool):
+    """Invoke one PyPSA stats method through the async statistics endpoint."""
+
+    name = "get_network_statistics"
+    description = (
+        "Get ONE aggregated PyPSA statistics method for a network. Each call "
+        "returns a single statistic — emit several tool_calls in one turn "
+        "when you need multiple methods.\n\n"
+        "Use these by question type:\n"
+        "- Capacity: installed_capacity, optimal_capacity, expanded_capacity\n"
+        "- Costs: capex, installed_capex, expanded_capex, fom, opex, system_cost\n"
+        "- Energy flows: supply, withdrawal, transmission, energy_balance\n"
+        "- Performance: capacity_factor, curtailment\n"
+        "- Economic: revenue, market_value, prices\n\n"
+        "All results are aggregated over time. `groupby` controls the "
+        "dimension (carrier/bus/country); `groupby_time` controls temporal "
+        "aggregation (sum/mean/max/min). Methods that depend on optimisation "
+        "results return empty data with a `network_not_solved` warning when "
+        "the network has not been solved."
+    )
+    parameters_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "network_id": {
+                "type": "string",
+                "description": "UUID of the network. Get ids from list_networks.",
+            },
+            "statistic": {
+                "type": "string",
+                "enum": sorted(ALLOWED_STATISTICS),
+                "description": "Which PyPSA stats method to invoke.",
+            },
+            "groupby": {
+                "type": "string",
+                "enum": ["carrier", "bus", "country"],
+                "description": "How to group results. Default 'carrier'.",
+            },
+            "groupby_time": {
+                "type": "string",
+                "enum": ["sum", "mean", "max", "min"],
+                "description": "How to aggregate temporal statistics.",
+            },
+            "groupby_method": {
+                "type": "string",
+                "enum": ["sum", "mean", "min", "max", "first", "last"],
+                "description": "How to aggregate values within the same group.",
+            },
+            "carrier": {
+                "type": "string",
+                "description": "Filter to a specific carrier name.",
+            },
+            "bus_carrier": {
+                "type": "string",
+                "description": ("Filter to a specific bus carrier (e.g. 'AC', 'DC')."),
+            },
+            "nice_names": {
+                "type": "boolean",
+                "description": (
+                    "Use human-readable carrier/component names. Default true."
+                ),
+            },
+        },
+        "required": ["network_id", "statistic"],
+    }
+
+    poll_interval_seconds: float = 0.25
+    poll_max_attempts: int = 480  # ~120 s at the default interval
+
+    async def invoke(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        network_id = args["network_id"]
+        statistic = args["statistic"]
+
+        parameters: dict[str, Any] = {
+            k: args[k] for k in _OPTIONAL_PARAMS if args.get(k) is not None
+        }
+        if "nice_names" in args:
+            parameters["nice_names"] = args["nice_names"]
+
+        cookies = cookies_for(ctx)
+        queued = await self._http.post(
+            "/api/v1/statistics/",
+            json={
+                "network_ids": [network_id],
+                "statistic": statistic,
+                "parameters": parameters,
+            },
+            cookies=cookies,
+        )
+        queued.raise_for_status()
+        task_id = queued.json()["task_id"]
+
+        for _ in range(self.poll_max_attempts):
+            poll = await self._http.get(
+                f"/api/v1/tasks/status/{task_id}",
+                cookies=cookies,
+            )
+            poll.raise_for_status()
+            status = poll.json()
+            state = status.get("state")
+            if state == "SUCCESS":
+                inner = status.get("result") or {}
+                return self._post_process(network_id, statistic, inner.get("data"))
+            if state == "FAILURE":
+                err = status.get("error") or "task failed"
+                return ToolResult(payload=None, is_error=True, error=err)
+            if self.poll_interval_seconds > 0:
+                await asyncio.sleep(self.poll_interval_seconds)
+
+        msg = f"task {task_id} polling timed out"
+        return ToolResult(payload=None, is_error=True, error=msg)
+
+    def _post_process(self, network_id: str, statistic: str, raw: object) -> ToolResult:
+        columns, rows = _to_table(raw)
+        warnings: list[str] = []
+        if not rows and statistic in _REQUIRES_OPTIMISATION:
+            warnings.append("network_not_solved")
+
+        units = _UNITS.get(statistic, "unknown")
+        suffix = ", network_not_solved" if "network_not_solved" in warnings else ""
+        summary_text = (
+            f"{statistic} for network {network_id} — {len(rows)} entries{suffix}."
+        )
+
+        return ToolResult(
+            payload={
+                "summary": summary_text,
+                "data": {"columns": columns, "rows": rows},
+                "display_hint": "table",
+                "network_id": network_id,
+                "statistic": statistic,
+                "units": units,
+                "warnings": warnings,
+            }
+        )
+
+
+def _to_table(raw: object) -> tuple[list[str], list[list[Any]]]:
+    """Reshape ``serialize_df`` output into renderer-friendly columns+rows.
+
+    DataFrame split-format -> ``["index", *columns]`` headers; rows prepended
+    with the index value. Series flat dict -> ``["index", "value"]``.
+    """
+    if isinstance(raw, dict) and "index" in raw and "columns" in raw and "data" in raw:
+        return (
+            ["index", *list(raw["columns"])],
+            [[idx, *row] for idx, row in zip(raw["index"], raw["data"], strict=False)],
+        )
+    if isinstance(raw, dict):
+        return ["index", "value"], [[k, v] for k, v in raw.items()]
+    return [], []

--- a/src/pypsa_app/llm/tools/http_client.py
+++ b/src/pypsa_app/llm/tools/http_client.py
@@ -1,0 +1,41 @@
+"""Shared httpx.AsyncClient used by tool implementations to call REST endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from pypsa_app.backend.settings import Settings
+    from pypsa_app.llm.tools.base import ToolContext
+
+
+def build_internal_http_client(settings: Settings) -> httpx.AsyncClient:
+    """Build an httpx.AsyncClient pointed at the app's own REST API.
+
+    The base URL is resolved from ``settings.llm``:
+
+    * If ``llm_internal_api_base`` is explicitly set, that value is used
+      directly.
+    * Otherwise the client defaults to
+      ``http://127.0.0.1:{llm_internal_port}`` (port 8000 by default).
+
+    The returned client has a 30-second timeout.  Tool implementations
+    forward the user's auth cookie on each call so that all per-user
+    auth, permission, and ownership checks apply automatically.
+    """
+    base = settings.llm.resolved_internal_api_base
+    return httpx.AsyncClient(base_url=base, timeout=30.0, follow_redirects=True)
+
+
+def cookies_for(ctx: ToolContext) -> dict[str, str] | None:
+    """Return a cookie dict for internal HTTP calls forwarding the user's session.
+
+    When ``ctx.auth_cookie`` is set, returns ``{"pypsa_session": ctx.auth_cookie}``
+    so the called endpoint sees the same authenticated user. The cookie name
+    must match SESSION_COOKIE_NAME in backend/settings.py.
+    Returns ``None`` when there is no auth cookie (e.g. unauthenticated or
+    no session established).
+    """
+    return {"pypsa_session": ctx.auth_cookie} if ctx.auth_cookie else None

--- a/src/pypsa_app/llm/tools/list_networks.py
+++ b/src/pypsa_app/llm/tools/list_networks.py
@@ -1,0 +1,140 @@
+"""Tool: list available networks visible to the current user, paginated."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pypsa_app.llm.tools.base import Tool, ToolContext, ToolResult
+from pypsa_app.llm.tools.http_client import cookies_for
+
+logger = logging.getLogger(__name__)
+
+
+def _last_updated(item: dict[str, Any]) -> str | None:
+    history = item.get("update_history") or []
+    if history:
+        return history[-1]
+    return item.get("created_at")
+
+
+class ListNetworksTool(Tool):
+    """List networks the user has access to, with pagination."""
+
+    name = "list_networks"
+    description = (
+        "List PyPSA energy networks visible to the current user, with "
+        "pagination. Returns each network's id, name, creation date, "
+        "visibility, and whether the current user owns it. Networks "
+        "marked is_owner=false are public networks owned by other "
+        "users.\n\n"
+        "Use when the user asks about their networks, wants an "
+        "overview, or needs network ids before drilling in.\n\n"
+        "Results are paginated. Default page size is 25, maximum 100. "
+        "The response includes total, has_more, and next_offset. To "
+        "see the next page, call again with offset=next_offset and the "
+        "same sort_by and order. Sort by created_at (default) or name; "
+        "order desc (default) or asc."
+    )
+    parameters_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "offset": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 0,
+                "description": "Number of networks to skip (for pagination).",
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "default": 25,
+                "description": "Maximum networks to return per page (1-100).",
+            },
+            "sort_by": {
+                "type": "string",
+                "enum": ["created_at", "name"],
+                "default": "created_at",
+                "description": "Field to sort by.",
+            },
+            "order": {
+                "type": "string",
+                "enum": ["asc", "desc"],
+                "default": "desc",
+                "description": "Sort direction.",
+            },
+        },
+    }
+
+    async def invoke(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        limit = max(1, min(int(args.get("limit", 25)), 100))
+        offset = max(0, int(args.get("offset", 0)))
+        sort_by = args.get("sort_by", "created_at")
+        order = args.get("order", "desc")
+        r = await self._http.get(
+            "/api/v1/networks/",
+            params={
+                "limit": limit,
+                "skip": offset,
+                "sort_by": sort_by,
+                "order": order,
+            },
+            cookies=cookies_for(ctx),
+        )
+        r.raise_for_status()
+        body = r.json()
+        items = body.get("data", [])
+        meta = body.get("meta") or {}
+        total = int(meta.get("total", len(items)))
+
+        user_id = ctx.user_id
+        rows = [
+            [
+                n.get("id"),
+                n.get("name") or n.get("filename", ""),
+                n.get("visibility", "private"),
+                (n.get("owner") or {}).get("id") == user_id,
+                _last_updated(n),
+            ]
+            for n in items
+        ]
+
+        returned = len(rows)
+        has_more = (offset + returned) < total
+        next_offset = (offset + returned) if has_more else None
+
+        more_hint = (
+            f" {total - offset - returned} more available — "
+            f"call again with offset={next_offset}."
+            if has_more
+            else ""
+        )
+        summary = (
+            f"Found {returned} networks (showing {offset + 1}-"
+            f"{offset + returned} of {total})." + more_hint
+        )
+
+        return ToolResult(
+            payload={
+                "summary": summary,
+                "data": {
+                    "columns": [
+                        "id",
+                        "name",
+                        "visibility",
+                        "is_owner",
+                        "modified",
+                    ],
+                    "rows": rows,
+                    "total": total,
+                    "offset": offset,
+                    "returned": returned,
+                    "has_more": has_more,
+                    "next_offset": next_offset,
+                    "sort_by": sort_by,
+                    "order": order,
+                },
+                "display_hint": "table",
+            }
+        )


### PR DESCRIPTION
## Summary

Adds an LLM chat backend to pypsa-app with provider-agnostic configuration (OpenRouter, Ollama, or any OpenAI-compatible API).

### What's included

- **`llm/` package**: LiteLLM client, chat service with multi-step tool-use loop, AG-UI SSE event streaming, system prompts
- **LLM tools**: `list_networks`, `get_network_detail`, `get_network_statistics`
- **Chat API**: `POST /chat/stream` (SSE), `GET /chat/health`
- **`LLMSettings`**: provider-agnostic config via env vars (`LLM_PROVIDER`, `LLM_API_KEY`, `LLM_API_BASE`, `LLM_MODEL`)
- **Feature flag**: `CHAT_ENABLED` wired through `/version` endpoint
- **Dependency**: `litellm>=1.83` added to `pyproject.toml`

### Not included (future PRs)

- Frontend chat UI
- Conversation persistence
- Stop/interrupt cleanup for partial messages